### PR TITLE
refactor: remove excessive withRouter HOC

### DIFF
--- a/src/components/Main/scenes/FabricView/components/FabricGrid/FabricGrid.js
+++ b/src/components/Main/scenes/FabricView/components/FabricGrid/FabricGrid.js
@@ -1,7 +1,6 @@
 import { Actions } from "jumpstate";
 import { PropTypes } from "prop-types";
 import React, { Component } from "react";
-import { withRouter } from "react-router";
 
 import withUrlState from "components/withUrlState";
 import { reportError } from "services/notification";
@@ -153,4 +152,4 @@ class FabricGrid extends Component {
   }
 }
 
-export default withRouter(withUrlState()(FabricGrid));
+export default withUrlState()(FabricGrid);


### PR DESCRIPTION
Resolves #1440 

## Proposed Changes

  - Remove withRouter, we we already are getting passed the React Router props

## How to Test

  - Start app and confirm that the FabricGrid is loads and re-renders
