### PR TITLE
feat: refactor testcafe.sh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3224,6 +3224,15 @@
         "electron-to-chromium": "1.3.27"
       }
     },
+    "browserstack": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.0.tgz",
+      "integrity": "sha1-tWVCWtYu1ywQgqHrl51TE8fUdU8=",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "1.0.0"
+      }
+    },
     "browserstack-local": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browserstack-local/-/browserstack-local-1.3.0.tgz",
@@ -8774,6 +8783,12 @@
         "is-glob": "2.0.1"
       }
     },
+    "glob-promise": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.3.0.tgz",
+      "integrity": "sha512-X5VIEO/yy5NH3p9ORhlNodakQo/cK4I0lCtARNeAkWueJiToew5Xs9DiukVKsW5dgpjnnQgou9Rbj3HUkM6OUw==",
+      "dev": true
+    },
     "glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
@@ -8818,6 +8833,12 @@
           }
         }
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.1.0.tgz",
+      "integrity": "sha1-4DadQmV4/UVtR9wjsJ3gXB2p6l0=",
+      "dev": true
     },
     "global": {
       "version": "4.3.2",
@@ -13301,6 +13322,24 @@
       "version": "0.6.33",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
       "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw="
+    },
+    "node-glob": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-glob/-/node-glob-1.2.0.tgz",
+      "integrity": "sha1-UkD/7e/G1mPOhRXleWpNR6dQwNU=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob-to-regexp": "0.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
     },
     "node-gyp": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-react": "^6.24.1",
+    "browserstack": "^1.5.0",
     "commander": "^2.12.2",
     "conventional-changelog-cli": "^1.3.5",
     "cors": "^2.8.4",
@@ -109,6 +110,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-config-react-app": "^2.0.1",
     "eslint-plugin-prettier": "^2.4.0",
+    "glob-promise": "^3.3.0",
     "husky": "^0.15.0-beta.16",
     "jest": "^22.0.6",
     "jest-cli": "^22.0.6",
@@ -119,6 +121,7 @@
     "lint-staged": "^6.0.0",
     "lodash-webpack-plugin": "^0.11.4",
     "moxios": "^0.4.0",
+    "node-glob": "^1.2.0",
     "node-sass": "^4.7.2",
     "npm-check": "^5.5.2",
     "npm-run-all": "^4.1.2",
@@ -144,38 +147,30 @@
   },
   "scripts": {
     "build": "node scripts/build.js",
-    "build-docker":
-      "docker build -t deciphernow/gm-fabric-dashboard -f docker-prod/Dockerfile .",
+    "build-docker": "docker build -t deciphernow/gm-fabric-dashboard -f docker-prod/Dockerfile .",
     "build-storybook": "build-storybook",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "draft-github-release": "node scripts/generateGitHubDraft.js",
-    "docs":
-      "cross-env NODE_ENV=production node ./node_modules/documentation/bin/documentation.js build src/index.js -f md -o docs.md",
-    "eslint-prettier-check":
-      "node ./node_modules/eslint/bin/eslint --print-config .eslintrc | eslint-config-prettier-check",
+    "docs": "cross-env NODE_ENV=production node ./node_modules/documentation/bin/documentation.js build src/index.js -f md -o docs.md",
+    "eslint-prettier-check": "node ./node_modules/eslint/bin/eslint --print-config .eslintrc | eslint-config-prettier-check",
     "format": "prettier --write 'src/**/*.{js,jsx}'",
     "junit-merge": "junit-merge",
     "lint-css": "stylelint --formatter string 'src/**/*.{js,jsx}'",
     "lint-js": "node ./node_modules/eslint/bin/eslint 'src'",
     "mock-sds": "node json-mock/discovery-service/sds.js",
-    "preversion":
-      "NODE_ENV=test CI=true npm-run-all --print-label lint-css lint-js test test:e2e:local",
+    "preversion": "NODE_ENV=test CI=true npm-run-all --print-label lint-css lint-js test test:e2e:local",
     "publish": "node scripts/publish.js",
-    "report-dep-licenses":
-      "license-checker --summary --out licenses/summary.txt && license-checker --csv --customPath licenses/licenseReportFormat.json --out licenses/report.csv",
+    "report-dep-licenses": "license-checker --summary --out licenses/summary.txt && license-checker --csv --customPath licenses/licenseReportFormat.json --out licenses/report.csv",
     "start": "npm run start-all",
     "start-all": "npm-run-all --print-label --parallel start-ui mock-sds",
     "start-ui": "node scripts/start.js",
     "storybook": "start-storybook -p 6006",
-    "test":
-      "TZ=/usr/share/zoneinfo/America/New_York node scripts/test.js --env=jsdom",
-    "test:e2e:local":
-      "testcafe chrome:headless ./e2e-tests/tests/*.js -a 'npm start' --app-init-delay 5000",
+    "test": "TZ=/usr/share/zoneinfo/America/New_York node scripts/test.js --env=jsdom",
+    "test:e2e:local": "testcafe chrome:headless ./e2e-tests/tests/*.js -a 'npm start' --app-init-delay 5000",
     "test:e2e": "node scripts/testcafe.js",
     "update-deps": "npm-check . --skip-unused -u",
     "update-snapshots": "CI=true npm run test -- --updateSnapshot",
-    "version":
-      "npm-run-all --print-label changelog update-snapshots && git add -A"
+    "version": "npm-run-all --print-label changelog update-snapshots && git add -A"
   },
   "husky": {
     "hooks": {
@@ -184,7 +179,10 @@
     }
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "jest-junit": {
     "suiteName": "GM Fabric",
@@ -194,15 +192,18 @@
     "usePathForSuiteName": "true"
   },
   "jest": {
-    "collectCoverageFrom": ["src/**/*.{js,jsx}"],
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}"
+    ],
     "setupFiles": [
       "<rootDir>/config/polyfills.js",
       "raf/polyfill",
       "<rootDir>/config/jest/jestSetup.js"
     ],
-    "setupTestFrameworkScriptFile":
-      "<rootDir>/config/jest/jestTestFrameworkSetup.js",
-    "snapshotSerializers": ["enzyme-to-json/serializer"],
+    "setupTestFrameworkScriptFile": "<rootDir>/config/jest/jestTestFrameworkSetup.js",
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.js?(x)",
       "<rootDir>/src/**/?(*.)(spec|test).js?(x)"
@@ -214,15 +215,28 @@
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+    ],
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     },
-    "moduleDirectories": ["node_modules", "<rootDir>/src"],
-    "moduleFileExtensions": ["web.js", "js", "json", "web.jsx", "jsx"]
+    "moduleDirectories": [
+      "node_modules",
+      "<rootDir>/src"
+    ],
+    "moduleFileExtensions": [
+      "web.js",
+      "js",
+      "json",
+      "web.jsx",
+      "jsx"
+    ]
   },
   "babel": {
-    "presets": ["react-app"]
+    "presets": [
+      "react-app"
+    ]
   },
   "prettier": {
     "bracketSpacing": true,
@@ -235,7 +249,9 @@
     "useTabs": false
   },
   "commitlint": {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   },
   "browserslist": [
     "last 2 Chrome versions",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
       "TZ=/usr/share/zoneinfo/America/New_York node scripts/test.js --env=jsdom",
     "test:e2e:local":
       "testcafe chrome:headless ./e2e-tests/tests/*.js -a 'npm start' --app-init-delay 5000",
-    "test:e2e": "./scripts/testcafe.sh",
+    "test:e2e": "node scripts/testcafe.js",
     "update-deps": "npm-check . --skip-unused -u",
     "update-snapshots": "CI=true npm run test -- --updateSnapshot",
     "version":

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -1,5 +1,6 @@
 const createTestCafe = require("testcafe");
 const glob = require("glob-promise");
+const BrowserStack = require("browserstack");
 
 // Each sub array defines a batch of browserstack workers.
 // Our current plan allows for a max of 5 workers at a time,
@@ -21,6 +22,28 @@ const SUPPORTED_BROWSERS = [
   ]
 ];
 
+const browserStackCredentials = {
+  username: process.env.BROWSERSTACK_USERNAME,
+  password: process.env.BROWSERSTACK_PASSWORD
+};
+
+async function getFiles(globPattern) {
+  return await glob(globPattern)
+    .then(files => files)
+    .catch(e => console.error(e));
+}
+
+async function getRunningBrowserstackSessions() {
+  const client = BrowserStack.createClient(browserStackCredentials);
+  const workerStatus = await new Promise(function(resolve, reject) {
+    client.getApiStatus((error, workers) => {
+      if (error) reject(error);
+      else resolve(workers);
+    });
+  });
+  return workerStatus;
+}
+
 async function createTestCafeInstance(browser, files) {
   let testcafe;
   await createTestCafe()
@@ -29,7 +52,7 @@ async function createTestCafeInstance(browser, files) {
       return tc
         .createRunner()
         .startApp("npm start")
-        .src(files)
+        .src("e2e-tests/tests/service-view.js")
         .browsers(browser)
         .run();
     })
@@ -41,17 +64,20 @@ async function createTestCafeInstance(browser, files) {
 }
 
 async function startTests(browsers, createTestCafeInstance) {
+  // The testcafe node api does not accept glob patterns, so grab relevant test files using node-glob
   let files = await getFiles("e2e-tests/tests/*.js");
-  for (let i = 0; i < browsers.length; i++) {
-    await createTestCafeInstance(browsers[i], files);
+  // Check that there are no tests already running
+  let sessionInfo = await getRunningBrowserstackSessions();
+  if (sessionInfo.running_sessions !== 0) {
+    console.error(
+      "There are not enough available Browserstack workers to run these tests. Please cancel any running sessions from the Browserstack Automate dashboard and try again."
+    );
+  } else {
+    // Create a new testcafe instance for each batch of browsers
+    for (let i = 0; i < browsers.length; i++) {
+      await createTestCafeInstance(browsers[i], files);
+    }
   }
-}
-
-async function getFiles(globPattern) {
-  const files = await glob(globPattern)
-    .then(files => files)
-    .catch(e => console.error(e));
-  return files;
 }
 
 startTests(SUPPORTED_BROWSERS, createTestCafeInstance);

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -1,32 +1,48 @@
 const createTestCafe = require("testcafe");
 
+// Each sub array defines a batch of browserstack workers.
+// Our current plan allows for a max of 5 workers at a time,
+// so to avoid crashing browserstack we group our browsers
+// into 2 batches that run will run consecutively.
 const SUPPORTED_BROWSERS = [
-  "browserstack:chrome@64.0:OS X High Sierra",
-  "browserstack:chrome@63.0:OS X High Sierra",
-  "browserstack:firefox@58.0:OS X High Sierra",
-  "browserstack:firefox@57.0:OS X High Sierra",
-  "browserstack:safari@11.0:OS X High Sierra",
-  "browserstack:safari@10.1:OS X Sierra",
-  "browserstack:edge@16.0:Windows 10",
-  "browserstack:edge@15.0:Windows 10",
-  "browserstack:ie@11.0:Windows 10"
+  [
+    "browserstack:chrome@64.0:OS X High Sierra",
+    "browserstack:chrome@63.0:OS X High Sierra",
+    "browserstack:firefox@58.0:OS X High Sierra",
+    "browserstack:firefox@57.0:OS X High Sierra"
+  ],
+  [
+    "browserstack:safari@11.0:OS X High Sierra",
+    "browserstack:safari@10.1:OS X Sierra",
+    "browserstack:edge@16.0:Windows 10",
+    "browserstack:edge@15.0:Windows 10",
+    "browserstack:ie@11.0:Windows 10"
+  ]
 ];
 
-let testcafe;
-// The following is an alternate method for initializing testcafe.
-// TODO: implement this so we can delete the bash script #1513
-createTestCafe("localhost", 9000)
-  .then(tc => {
-    testcafe = tc;
-    return tc
-      .createRunner()
-      .startApp("npm start")
-      .src("tests/sample.js")
-      .browsers("browserstack:chrome@64.0:OS X High Sierra")
-      .run();
-  })
-  .then(failedCount => {
-    console.log("Tests failed: " + failedCount);
-    testcafe.close();
-  })
-  .catch(err => console.error(err));
+async function createTestCafeInstance(browser) {
+  let testcafe;
+  await createTestCafe("localhost")
+    .then(tc => {
+      testcafe = tc;
+      return tc
+        .createRunner()
+        .startApp("npm start")
+        .src("e2e-tests/tests/service-view.js")
+        .browsers(browser)
+        .run();
+    })
+    .then(failedCount => {
+      console.log("Tests failed: " + failedCount);
+      testcafe.close();
+    })
+    .catch(err => console.error(err));
+}
+
+async function startTests(browsers, createTestCafeInstance) {
+  for (let index = 0; index < browsers.length; index++) {
+    await createTestCafeInstance(browsers[index]);
+  }
+}
+
+startTests(SUPPORTED_BROWSERS, createTestCafeInstance);

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -6,23 +6,23 @@ const createTestCafe = require("testcafe");
 // into 2 batches that run will run consecutively.
 const SUPPORTED_BROWSERS = [
   [
-    "browserstack:chrome@64.0:OS X High Sierra",
-    "browserstack:chrome@63.0:OS X High Sierra",
-    "browserstack:firefox@58.0:OS X High Sierra",
-    "browserstack:firefox@57.0:OS X High Sierra"
-  ],
-  [
     "browserstack:safari@11.0:OS X High Sierra",
     "browserstack:safari@10.1:OS X Sierra",
     "browserstack:edge@16.0:Windows 10",
     "browserstack:edge@15.0:Windows 10",
     "browserstack:ie@11.0:Windows 10"
+  ],
+  [
+    "browserstack:chrome@64.0:OS X High Sierra",
+    "browserstack:chrome@63.0:OS X High Sierra",
+    "browserstack:firefox@58.0:OS X High Sierra",
+    "browserstack:firefox@57.0:OS X High Sierra"
   ]
 ];
 
 async function createTestCafeInstance(browser) {
   let testcafe;
-  await createTestCafe("localhost")
+  await createTestCafe()
     .then(tc => {
       testcafe = tc;
       return tc
@@ -36,7 +36,10 @@ async function createTestCafeInstance(browser) {
       console.log("Tests failed: " + failedCount);
       testcafe.close();
     })
-    .catch(err => console.error(err));
+    .catch(err => {
+      console.error(err);
+      testcafe.close();
+    });
 }
 
 async function startTests(browsers, createTestCafeInstance) {

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -52,7 +52,7 @@ async function createTestCafeInstance(browser, files) {
       return tc
         .createRunner()
         .startApp("npm start")
-        .src("e2e-tests/tests/service-view.js")
+        .src(files)
         .browsers(browser)
         .run();
     })

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -36,10 +36,7 @@ async function createTestCafeInstance(browser) {
       console.log("Tests failed: " + failedCount);
       testcafe.close();
     })
-    .catch(err => {
-      console.error(err);
-      testcafe.close();
-    });
+    .catch(err => testcafe.close());
 }
 
 async function startTests(browsers, createTestCafeInstance) {

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -28,7 +28,7 @@ async function createTestCafeInstance(browser) {
       return tc
         .createRunner()
         .startApp("npm start")
-        .src("e2e-tests/tests/service-view.js")
+        .src("e2e-tests/tests/*.js")
         .browsers(browser)
         .run();
     })
@@ -40,8 +40,8 @@ async function createTestCafeInstance(browser) {
 }
 
 async function startTests(browsers, createTestCafeInstance) {
-  for (let index = 0; index < browsers.length; index++) {
-    await createTestCafeInstance(browsers[index]);
+  for (let i = 0; i < browsers.length; i++) {
+    await createTestCafeInstance(browsers[i]);
   }
 }
 

--- a/scripts/testcafe.js
+++ b/scripts/testcafe.js
@@ -1,6 +1,4 @@
 const createTestCafe = require("testcafe");
-const BrowserStack = require("browserstack");
-const util = require("util");
 const glob = require("glob-promise");
 
 // Each sub array defines a batch of browserstack workers.
@@ -49,8 +47,8 @@ async function startTests(browsers, createTestCafeInstance) {
   }
 }
 
-async function getFiles(glob) {
-  const files = await glob(glob)
+async function getFiles(globPattern) {
+  const files = await glob(globPattern)
     .then(files => files)
     .catch(e => console.error(e));
   return files;

--- a/scripts/testcafe.sh
+++ b/scripts/testcafe.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-browsers=("browserstack:chrome@64.0:OS X High Sierra,browserstack:chrome@63.0:OS X High Sierra,browserstack:firefox@58.0:OS X High Sierra,browserstack:firefox@57.0:OS X High Sierra" "browserstack:safari@11.0:OS X High Sierra,browserstack:safari@10.1:OS X Sierra,browserstack:edge@16.0:Windows 10,browserstack:edge@15.0:Windows 10,browserstack:ie@11.0:Windows 10")
-
-for i in "${browsers[@]}"
-do
-  ./node_modules/.bin/testcafe "${i}" e2e-tests/tests/*.js -r xunit:browserstack-results/res.xml --app 'npm start'
-done


### PR DESCRIPTION
Resolves #1513 

## Proposed Changes

  - Created a node script that functions basically the same as the previous bash script solution with a few added features
  - Used the browserstack node api to check how many workers are available. The script will only start running our batches of tests if there are no other running sessions.
- Apparently the testcafe node api can't handle glob patterns in the .src() method, so I created a helper function to grab our test files.
 - Deleted the bash script.
  
## How to Test

- `npm i`
- add `BROWSERSTACK_USERNAME` and `BROWSERSTACK_PASSWORD` to your bash/zsh profile
-  temporarily delete `e2e-tests/tests/base-instance-view.js` and `e2e-tests/tests/fabric-view.js` because these test are failing and I'll deal with it later
-  `npm run test:e2e` and check out the [browserstack automate dashboard](https://www.browserstack.com/automate). Confirm that the tests run in batches as defined in the SUPPORTED_BROWSERS array.
- once that completes successfully, `npm run test:e2e` again,  and then open up a new terminal and then run it a 2nd time. You should get an error that there aren't enough browserstack workers available.

