### PR TITLE
chore: replace node:8 with node:8-alpine to shrink docker image

### DIFF
--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-alpine
 ENV NODE_ENV=production
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Resolves #1569

## Proposed Changes

  - Change the base Docker image from node:8 to node:8-alpine to shrink the docker image size
  
## How to Test
  - `npm run build`
  - `npm run build-docker`
  - `docker run -p 1338:1338 -e PORT='1338' -e FABRIC_SERVER='http://localhost:1337' -it deciphernow/gm-fabric-dashboard`
  - Then in a second terminal, `npm run mock-sds`


